### PR TITLE
https or http backend 선택 로직 버그 수정 & 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@day1co/http-request-sync",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/http-request-sync",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.21",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
-        "eslint": "^8.10.0",
+        "eslint": "^8.11.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
@@ -616,16 +616,16 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -633,15 +633,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2331,12 +2322,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
+      "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.0",
+        "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -6693,28 +6684,20 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -8000,12 +7983,12 @@
       }
     },
     "eslint": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
+      "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.0",
+        "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/http-request-sync",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "quick and dirty synchoronous wrapper of http.request",
   "author": "Day1Company",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
-    "eslint": "^8.10.0",
+    "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^4.0.0",

--- a/src/http-request-async.spec.ts
+++ b/src/http-request-async.spec.ts
@@ -5,14 +5,50 @@ describe('http-request-async', () => {
     it('should do GET', async () => {
       const TEST_URL = 'http://httpbin.org/get';
       const res = await httpRequestAsync(TEST_URL);
+      expect(res.statusCode).toBe(200);
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with URL', async () => {
+      const TEST_URL = 'http://httpbin.org/get';
+      const res = await httpRequestAsync(new URL(TEST_URL));
+      expect(res.statusCode).toBe(200);
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET 404', async () => {
+      const TEST_URL = 'http://httpbin.org/status/404';
+      const res = await httpRequestAsync(TEST_URL);
+      expect(res.statusCode).toBe(404);
     });
     it('should do GET via https', async () => {
       const TEST_URL = 'https://httpbin.org/get';
       const res = await httpRequestAsync(TEST_URL);
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with URL via https', async () => {
+      const TEST_URL = 'https://httpbin.org/get';
+      const res = await httpRequestAsync(new URL(TEST_URL));
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with options.port via https', async () => {
+      const TEST_URL = 'https://httpbin.org/get';
+      const res = await httpRequestAsync({ host: 'httpbin.org', path: '/get', port: 443 });
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with options.protocol via https', async () => {
+      const TEST_URL = 'https://httpbin.org/get';
+      const res = await httpRequestAsync({ host: 'httpbin.org', path: '/get', protocol: 'https:' });
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET 404 via https', async () => {
+      const TEST_URL = 'https://httpbin.org/status/404';
+      const res = await httpRequestAsync(TEST_URL);
+      expect(res.statusCode).toBe(404);
     });
   });
 });

--- a/src/http-request-sync.spec.ts
+++ b/src/http-request-sync.spec.ts
@@ -5,14 +5,51 @@ describe('http-request-sync', () => {
     it('should do GET', () => {
       const TEST_URL = 'http://httpbin.org/get';
       const res = httpRequestSync(TEST_URL);
+      expect(res.statusCode).toBe(200);
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with URL', async () => {
+      const TEST_URL = 'http://httpbin.org/get';
+      const res = await httpRequestSync(new URL(TEST_URL));
+      expect(res.statusCode).toBe(200);
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET 404', () => {
+      const TEST_URL = 'http://httpbin.org/status/404';
+      const res = httpRequestSync(TEST_URL);
+      expect(res.statusCode).toBe(404);
     });
     it('should do GET via https', () => {
       const TEST_URL = 'https://httpbin.org/get';
       const res = httpRequestSync(TEST_URL);
+      expect(res.statusCode).toBe(200);
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with URL via https', async () => {
+      const TEST_URL = 'https://httpbin.org/get';
+      const res = await httpRequestSync(new URL(TEST_URL));
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with options.port via https', async () => {
+      const TEST_URL = 'https://httpbin.org/get';
+      const res = await httpRequestSync({ host: 'httpbin.org', path: '/get', port: 443 });
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET with options.protocol via https', async () => {
+      const TEST_URL = 'https://httpbin.org/get';
+      const res = await httpRequestSync({ host: 'httpbin.org', path: '/get', protocol: 'https:' });
+      const data = JSON.parse(res.data);
+      expect(data.url).toBe(TEST_URL);
+    });
+    it('should do GET 404 via https', () => {
+      const TEST_URL = 'https://httpbin.org/status/404';
+      const res = httpRequestSync(TEST_URL);
+      expect(res.statusCode).toBe(404);
     });
   });
 });


### PR DESCRIPTION
1. `RequestOptions.protocol`은 `https:` 나 `http:`처럼 뒤에 `:`이 붙어있음. `URL`의 `protocol`은 `:`이 없음. ㅠㅠ
2. `URL` 인스턴스는 `workerData`로 전달할 수 없음: url 문자열로 변환해서 전달. ㅠㅠ
3. `URL`은 전역 클래스라 import가 필요없음
4. backend 모듈 선택 로직 개선
```typescript
const httpModule = isHttps ? https : http;
const req = httpModule.request(options, callback);
```
...를 하고싶었으나 컴파일 안됨.

```typescript
const req = isHttps ? https.request(options, callback) : http.request(options.callback);
```
...로 했으나...

그것보다는
```typescript
const request = isHttps ? https.request : http.request;
const req = request(options, callback);
```
...이 나을 것 같아서 수정.

하는 김에 테스트케이스 하나 더 추가.

하는 김에 버전 업.