### PR TITLE
Fix/apply try catch

### DIFF
--- a/src/http-request-sync.spec.ts
+++ b/src/http-request-sync.spec.ts
@@ -51,5 +51,11 @@ describe('http-request-sync', () => {
       const res = httpRequestSync(TEST_URL);
       expect(res.statusCode).toBe(404);
     });
+    it('should fail with invalid protocol', () => {
+      const TEST_URL = 'htt://httpbin.org/get';
+      const res = httpRequestSync(TEST_URL);
+      expect(res.statusCode).toBeUndefined();
+      expect(res).toHaveProperty('error');
+    });
   });
 });

--- a/src/http-request-sync.spec.ts
+++ b/src/http-request-sync.spec.ts
@@ -9,9 +9,9 @@ describe('http-request-sync', () => {
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
     });
-    it('should do GET with URL', async () => {
+    it('should do GET with URL', () => {
       const TEST_URL = 'http://httpbin.org/get';
-      const res = await httpRequestSync(new URL(TEST_URL));
+      const res = httpRequestSync(new URL(TEST_URL));
       expect(res.statusCode).toBe(200);
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
@@ -28,21 +28,21 @@ describe('http-request-sync', () => {
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
     });
-    it('should do GET with URL via https', async () => {
+    it('should do GET with URL via https', () => {
       const TEST_URL = 'https://httpbin.org/get';
-      const res = await httpRequestSync(new URL(TEST_URL));
+      const res = httpRequestSync(new URL(TEST_URL));
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
     });
-    it('should do GET with options.port via https', async () => {
+    it('should do GET with options.port via https', () => {
       const TEST_URL = 'https://httpbin.org/get';
-      const res = await httpRequestSync({ host: 'httpbin.org', path: '/get', port: 443 });
+      const res = httpRequestSync({ host: 'httpbin.org', path: '/get', port: 443 });
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
     });
-    it('should do GET with options.protocol via https', async () => {
+    it('should do GET with options.protocol via https', () => {
       const TEST_URL = 'https://httpbin.org/get';
-      const res = await httpRequestSync({ host: 'httpbin.org', path: '/get', protocol: 'https:' });
+      const res = httpRequestSync({ host: 'httpbin.org', path: '/get', protocol: 'https:' });
       const data = JSON.parse(res.data);
       expect(data.url).toBe(TEST_URL);
     });

--- a/src/http-request-sync.ts
+++ b/src/http-request-sync.ts
@@ -45,7 +45,8 @@ function resolve(res, data) {
 }
 
 function reject(error) {
-  port.postMessage(JSON.stringify({ error }));
+  const { stack } = error;
+  port.postMessage(JSON.stringify({ error: stack }));
   notify();
 }
 
@@ -57,38 +58,42 @@ const isHttps =
   (typeof options === 'object' && (options.port === 443 || options.protocol === 'https:'));
 const request = isHttps ? https.request : http.request;
 
-const req = request(options, (res) => {
-  log('statusCode:', res.statusCode);
-  log('headers:', res.headers);
-  res.setEncoding('utf8');
-  let data = '';
-  res.on('data', (chunk) => {
-    log('>' + chunk);
-    data += chunk;
+try {
+  const req = request(options, (res) => {
+    log('statusCode:', res.statusCode);
+    log('headers:', res.headers);
+    res.setEncoding('utf8');
+    let data = '';
+    res.on('data', (chunk) => {
+      log('>' + chunk);
+      data += chunk;
+    });
+    res.on('error', (error) => {
+      return reject(error);
+    });
+    res.on('end', () => {
+      return resolve(res, data);
+    });
   });
-  res.on('error', (error) => {
+  
+  req.on('error', (error) => {
+    log('error!', error, options, typeof options, options instanceof URL);
     return reject(error);
   });
-  res.on('end', () => {
-    return resolve(res, data);
+  req.on('timeout', () => {
+    log('timeout!');
+    return reject();
   });
-});
-
-req.on('error', (error) => {
-  log('error!', error, options, typeof options, options instanceof URL);
-  return reject(error);
-});
-req.on('timeout', () => {
-  log('timeout!');
-  return reject();
-});
-req.on('uncaughtException', (error) => {
-  log('uncaughtException!', error);
-  return reject(error);
-});
-req.end(() => {
-  log('end!');
-});
+  req.on('uncaughtException', (error) => {
+    log('uncaughtException!', error);
+    return reject(error);
+  });
+  req.end(() => {
+    log('end!');
+  });
+} catch (err) {
+  reject(err);
+}
   `,
     {
       eval: true,


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
sync 함수에서
요청하고자 하는 URL string이 invalid할 때 (ex : protocol이 유효하지 않거나...)
`http.request()` 코드 부분에서 에러가 발생하지만 해당 에러를 받아주는 곳이 없어 무한 sleep 하는 이슈가 있습니다.

## 무엇을 어떻게 변경했나요?
- worker 내부 코드에 try catch 적용
- catch 구문에서 reject() 호출
- worker가 전달하는 에러 메세지를 좀 더 상세하게 변경 `(JSON.stringify({ error }) -> JSON.stringify({ error: error.stack }))`
- httpRequestSync 테스트코드에 async await 삭제
- invalid한 http 요청 option에 대한 테스트케이스 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
npm test

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="543" alt="Screen Shot 2022-04-06 at 6 54 58 PM" src="https://user-images.githubusercontent.com/63729090/161949312-7a8c896a-0f6a-420e-bc41-d2b69e2f8ec2.png">

